### PR TITLE
feat: Add /health endpoint for service monitoring

### DIFF
--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,0 +1,20 @@
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health_check():
+    """
+    Health check endpoint for service monitoring.
+    Used by load balancers, Kubernetes probes, and alerting systems.
+    """
+    return {
+        "status": "ok",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "service": "product-api",
+        "version": "1.0.0",
+    }


### PR DESCRIPTION
## Summary

Adds a `/health` endpoint to the `product-api` service for infrastructure monitoring.

## Changes

- New file: `app/routes/health.py` — FastAPI router with `GET /health`
- Returns JSON payload with `status`, `timestamp`, `service`, and `version`
- No authentication required on this endpoint

## Example Response

```json
{
  "status": "ok",
  "timestamp": "2024-01-15T10:30:00+00:00",
  "service": "product-api",
  "version": "1.0.0"
}
```

## Testing

- Manual verification of endpoint response
- Unit tests to be added in a follow-up commit

## Related

Closes #1

## Checklist

- [x] Endpoint returns 200 with status payload
- [x] No authentication required
- [ ] Response time verified under 50ms
- [ ] Unit and integration tests (follow-up)